### PR TITLE
added custom generator example, fixed misleading indentation

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,6 +25,9 @@ target_link_libraries(exampleElementsGen cppqc)
 add_executable(testSlowShrinking src/TestSlowShrinking.cpp)
 target_link_libraries(testSlowShrinking cppqc)
 
+add_executable(testWithCustomGenerator src/TestWithCustomGenerator.cpp)
+target_link_libraries(testSlowShrinking cppqc)
+
 # requires c++1y compile flag
 #add_executable(testBoostTupleSupport src/BoostTupleSupport.cpp)
 #target_link_libraries(testBoostTupleSupport cppqc)

--- a/examples/src/TestWithCustomGenerator.cpp
+++ b/examples/src/TestWithCustomGenerator.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018, Amy de Buitléir All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cppqc.h"
+
+#include <random>
+#include <sstream>
+
+class Rectangle {
+public:
+  Rectangle (int w, int h) {
+    width = w;
+    height = h;
+  }
+  int getWidth() const { return width; }
+  int getHeight() const { return height; }
+  int getArea() const { return width*height; }
+  friend std::ostream& operator << (std::ostream& os, const Rectangle& r) {
+    os << "width: " << r.width << " height: " << r.height << std::endl;
+    return os ;
+  }
+private:
+  int width;
+  int height;
+};
+
+class CustomGenerator {
+public:
+  Rectangle unGen(cppqc::RngEngine &rng, std::size_t n) {
+    boost::random::uniform_int_distribution<> dist{1, static_cast<int>(n) + 1};
+    int w = dist(rng);
+    int h = (n + 1)/w;
+    return Rectangle(w, h);
+  }
+
+  std::vector<Rectangle> shrink(const Rectangle &r) {
+    std::vector<Rectangle> ret;
+    if (r.getWidth() > 1)
+      ret.push_back(Rectangle(r.getWidth()-1, r.getHeight()));
+    if (r.getHeight() > 1) {
+      ret.push_back(Rectangle(r.getWidth(), r.getHeight()-1));
+    }
+    return ret;
+  }
+};
+
+// A silly test just to demonstrate the custom generator.
+struct PropTestCustomGen : cppqc::Property<Rectangle>
+{
+  PropTestCustomGen() : Property(CustomGenerator()) {}
+    bool check(const Rectangle &r) const override
+    {
+      return (r.getArea() == r.getWidth() * r.getHeight());
+    }
+    std::string name() const override
+    {
+        return "TestCustomGen";
+    }
+};
+
+int main()
+{
+  cppqc::quickCheckOutput(PropTestCustomGen());
+}

--- a/examples/src/TestWithCustomGenerator.cpp
+++ b/examples/src/TestWithCustomGenerator.cpp
@@ -49,7 +49,7 @@ private:
 class CustomGenerator {
 public:
   Rectangle unGen(cppqc::RngEngine &rng, std::size_t n) {
-    boost::random::uniform_int_distribution<> dist{1, static_cast<int>(n) + 1};
+    std::uniform_int_distribution<> dist{1, static_cast<int>(n) + 1};
     int w = dist(rng);
     int h = (n + 1)/w;
     return Rectangle(w, h);

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -2913,7 +2913,7 @@ namespace Catch {
                 for( std::vector<Ptr<Pattern> >::const_iterator it = m_patterns.begin(), itEnd = m_patterns.end(); it != itEnd; ++it )
                     if( !(*it)->matches( testCase ) )
                         return false;
-                    return true;
+                return true;
             }
         };
 


### PR DESCRIPTION
I've added an example that uses a custom generator. My C++ skills are rusty, so please let me know if I should make any changes to it.

I've also fixed the compilation warning below.

```
In file included from /home/eamybut/nosync/src/CppQuickCheck/test/catch-main.cpp:27:0:
/home/eamybut/nosync/src/CppQuickCheck/test/catch.hpp: In member function ‘bool Catch::TestSpec::Filter::matches(const Catch::TestCaseInfo&) const’:
/home/eamybut/nosync/src/CppQuickCheck/test/catch.hpp:2913:17: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
                 for( std::vector<Ptr<Pattern> >::const_iterator it = m_patterns.begin(), itEnd = m_patterns.end(); it != itEnd; ++it )
                 ^~~
/home/eamybut/nosync/src/CppQuickCheck/test/catch.hpp:2916:21: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘for’
                     return true;
```