### PR TITLE
Add Arbitrary<> specializations for signed/unsigned long long

### DIFF
--- a/include/cppqc/Arbitrary.h
+++ b/include/cppqc/Arbitrary.h
@@ -244,6 +244,20 @@ struct ArbitraryImpl<unsigned long>
 };
 
 template<>
+struct ArbitraryImpl<signed long long>
+{
+    static const Arbitrary<signed long long>::unGenType unGen;
+    static const Arbitrary<signed long long>::shrinkType shrink;
+};
+
+template<>
+struct ArbitraryImpl<unsigned long long>
+{
+    static const Arbitrary<unsigned long long>::unGenType unGen;
+    static const Arbitrary<unsigned long long>::shrinkType shrink;
+};
+
+template<>
 struct ArbitraryImpl<float>
 {
     static const Arbitrary<float>::unGenType unGen;

--- a/src/Arbitrary.cpp
+++ b/src/Arbitrary.cpp
@@ -46,6 +46,16 @@ const Arbitrary<unsigned long>::unGenType ArbitraryImpl<unsigned long>::unGen =
 const Arbitrary<unsigned long>::shrinkType ArbitraryImpl<unsigned long>::shrink =
     shrinkIntegral<unsigned long>;
 
+const Arbitrary<signed long long>::unGenType ArbitraryImpl<signed long long>::unGen =
+    arbitrarySizedBoundedIntegral<signed long long>;
+const Arbitrary<signed long long>::shrinkType ArbitraryImpl<signed long long>::shrink =
+    shrinkIntegral<signed long long>;
+
+const Arbitrary<unsigned long long>::unGenType ArbitraryImpl<unsigned long long>::unGen =
+    arbitrarySizedBoundedIntegral<unsigned long long>;
+const Arbitrary<unsigned long long>::shrinkType ArbitraryImpl<unsigned long long>::shrink =
+    shrinkIntegral<unsigned long long>;
+
 const Arbitrary<float>::unGenType ArbitraryImpl<float>::unGen =
     arbitrarySizedReal<float>;
 const Arbitrary<float>::shrinkType ArbitraryImpl<float>::shrink = shrinkReal<float>;


### PR DESCRIPTION
This seems to just have been an oversight since C++11 standardized long long, AFAICT.