### PR TITLE
Update CMake and cpp files to fix the compilation on newer MSVC compi…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,21 @@
 cmake_minimum_required(VERSION 2.6)
 project(CppQuickCheck)
-set(CMAKE_CXX_FLAGS "-O3 -g -Wall -std=c++11")
+if(WIN32)
+    set(CMAKE_CXX_FLAGS "/W4 /permissive- /EHsc")
+else()
+    set(CMAKE_CXX_FLAGS "-O3 -g -Wall -std=c++11")
+endif()
 
-find_package(Boost REQUIRED)
-include_directories(${Boost_INCLUDE_DIR})
-
-include_directories("${PROJECT_SOURCE_DIR}/include")
-
-add_subdirectory(examples)
 
 add_library(cppqc SHARED src/Arbitrary.cpp)
+target_include_directories(cppqc PUBLIC include)
+
+option(CPPQC_USE_BOOST "Use Boost, allowing to build some of the examples." OFF)
+if(CPPQC_USE_BOOST)
+    find_package(Boost REQUIRED)
+endif()
+
+add_subdirectory(examples)
 
 install(DIRECTORY "include/" DESTINATION "include"
     PATTERN ".*" EXCLUDE)
@@ -23,11 +29,12 @@ add_executable(
   test/arbitrary-tests.cpp
   test/shrink-explosion-protection.cpp
   test/compact-check-tests.cpp
-  test/functional-tests.cpp)
-target_link_libraries(all-catch-tests cppqc)
+  test/functional-tests.cpp
+)
+target_link_libraries(all-catch-tests PRIVATE cppqc)
 add_test(all-catch-tests all-catch-tests)
 
-# workaround to force cmake to build test executable before running the test
+# workaround to force CMake to build test executable before running the test
 # (source: http://stackoverflow.com/a/736838/783510)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
                   DEPENDS all-catch-tests)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,33 +1,36 @@
-add_executable(sampleOutput src/sampleOutput.cpp)
-target_link_libraries(sampleOutput cppqc)
+if(CPPQC_USE_BOOST)
+    add_executable(sampleOutput src/sampleOutput.cpp)
+    target_link_libraries(sampleOutput PRIVATE cppqc)
+    target_include_directories(sampleOutput PUBLIC ${Boost_INCLUDE_DIR})
 
-add_executable(sampleShrinkOutput src/sampleShrinkOutput.cpp)
-target_link_libraries(sampleShrinkOutput cppqc)
-
+    add_executable(sampleShrinkOutput src/sampleShrinkOutput.cpp)
+    target_link_libraries(sampleShrinkOutput PRIVATE cppqc)
+    target_include_directories(sampleShrinkOutput PUBLIC ${Boost_INCLUDE_DIR})
+endif()
 add_executable(testReverse src/TestReverse.cpp)
-target_link_libraries(testReverse cppqc)
+target_link_libraries(testReverse PRIVATE cppqc)
 
 add_executable(testReverseArray src/TestReverseArray.cpp)
-target_link_libraries(testReverseArray cppqc)
+target_link_libraries(testReverseArray PRIVATE cppqc)
 
 add_executable(testSort src/TestSort.cpp)
-target_link_libraries(testSort cppqc)
+target_link_libraries(testSort PRIVATE cppqc)
 
 add_executable(testSortCompact src/TestSortCompact.cpp)
-target_link_libraries(testSortCompact cppqc)
+target_link_libraries(testSortCompact PRIVATE cppqc)
 
 add_executable(testChooseGenerator src/TestChooseGenerator.cpp)
-target_link_libraries(testChooseGenerator cppqc)
+target_link_libraries(testChooseGenerator PRIVATE cppqc)
 
 add_executable(exampleElementsGen src/exampleElementsGen.cpp)
-target_link_libraries(exampleElementsGen cppqc)
+target_link_libraries(exampleElementsGen PRIVATE cppqc)
 
 add_executable(testSlowShrinking src/TestSlowShrinking.cpp)
-target_link_libraries(testSlowShrinking cppqc)
+target_link_libraries(testSlowShrinking PRIVATE cppqc)
 
 add_executable(testWithCustomGenerator src/TestWithCustomGenerator.cpp)
-target_link_libraries(testSlowShrinking cppqc)
+target_link_libraries(testWithCustomGenerator PRIVATE cppqc)
 
 # requires c++1y compile flag
 #add_executable(testBoostTupleSupport src/BoostTupleSupport.cpp)
-#target_link_libraries(testBoostTupleSupport cppqc)
+#target_link_libraries(testBoostTupleSupport PRIVATE cppqc)

--- a/examples/src/TestReverseArray.cpp
+++ b/examples/src/TestReverseArray.cpp
@@ -25,8 +25,8 @@
 
 #include "cppqc.h"
 
+#include <array>
 #include <algorithm>
-#include <boost/static_assert.hpp>
 
 const int ArraySize = 5;
 

--- a/examples/src/TestSort.cpp
+++ b/examples/src/TestSort.cpp
@@ -26,7 +26,6 @@
 #include "cppqc.h"
 
 #include <algorithm>
-#include <boost/static_assert.hpp>
 #include <iterator>
 #include <sstream>
 

--- a/examples/src/TestSortCompact.cpp
+++ b/examples/src/TestSortCompact.cpp
@@ -27,7 +27,6 @@
 #include "cppqc/CompactCheck.h"
 
 #include <algorithm>
-#include <boost/static_assert.hpp>
 #include <iterator>
 #include <sstream>
 

--- a/include/cppqc/Generator.h
+++ b/include/cppqc/Generator.h
@@ -38,6 +38,7 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include <ctime>
 
 namespace cppqc {
 
@@ -233,7 +234,7 @@ std::vector<T> sample(const Generator<T>& g,
   if (num == 0)
     num = 20;
   if (seed == 0)
-    seed = time(nullptr);
+    seed = std::time(nullptr);
   RngEngine rng(seed);
   std::vector<T> ret;
   ret.reserve(num);
@@ -254,7 +255,7 @@ void sampleOutput(const Generator<T>& g,
   if (num == 0)
     num = 20;
   if (seed == 0)
-    seed = time(nullptr);
+    seed = std::time(nullptr);
   RngEngine rng(seed);
   try {
     for (std::size_t i = 0; i < num; ++i) {
@@ -276,7 +277,7 @@ std::vector<std::pair<T, std::vector<T>>> sampleShrink(const Generator<T>& g,
   if (num == 0)
     num = 20;
   if (seed == 0)
-    seed = time(nullptr);
+    seed = std::time(nullptr);
   RngEngine rng(seed);
   std::vector<std::pair<T, std::vector<T>>> ret;
   ret.reserve(num);
@@ -301,7 +302,7 @@ void sampleShrinkOutput(const Generator<T>& g,
   if (num == 0)
     num = 20;
   if (seed == 0)
-    seed = time(nullptr);
+    seed = std::time(nullptr);
   RngEngine rng(seed);
   try {
     for (std::size_t i = 0; i < num; ++i) {

--- a/include/cppqc/Test.h
+++ b/include/cppqc/Test.h
@@ -173,7 +173,7 @@ inline SeedType resolveSeed(SeedType originalSeed = USE_DEFAULT_SEED) {
         throw std::invalid_argument{err.str()};
       }
     } else {
-      return static_cast<SeedType>(time(0));
+      return static_cast<SeedType>(std::time(0));
     }
   } else {
     return originalSeed;

--- a/test/arbitrary-tests.cpp
+++ b/test/arbitrary-tests.cpp
@@ -26,6 +26,7 @@
 #include "catch.hpp"
 #include "cppqc/Arbitrary.h"
 
+#include <array>
 #include <random>
 #include <unordered_set>
 


### PR DESCRIPTION
Update CMake and cpp files to fix the compilation on newer MSVC compilers

- Add proper flags on when building on Windows.
- Remove all dependencies on Boost for the core CPP QuickCheck project. Also add an option to use Boost.
- Modernize some of the CMake infrastructure to use targets and target properties.
- Add type trait machinery to determine the correct type to use for std::uniform_int_distribution based on the standard.
- Fix non-standard call to std::time.
